### PR TITLE
Added net452 target

### DIFF
--- a/src/AssemblyFixture.csproj
+++ b/src/AssemblyFixture.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.1;netstandard2.0</TargetFrameworks>
     <Version>0.1.0</Version>
     <Authors>kzu, J.D. Cain</Authors>
     <Product />

--- a/test/AssemblyFixture.Tests.csproj
+++ b/test/AssemblyFixture.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds support for .NET Framework together with .NET Core

xunit.extensibility.execution targets .NET 4.5.2, so that is why I picked the same version.

The test project also now multitargets .NET 4.7.2, as that's the first framework version to target .NET Standard 2.0 to have test that verify it doesn't pick the .NET Standard 2.0 version.