### PR TITLE
Give DiagnosticsMessageSink to fixture if requested

### DIFF
--- a/src/TestAssemblyRunner.cs
+++ b/src/TestAssemblyRunner.cs
@@ -49,10 +49,19 @@ namespace Xunit.Extensions.AssemblyFixture
                 foreach (Type fixtureAttribute in assemblyFixtures)
                 {
                     Type fixtureType = fixtureAttribute.GetGenericArguments()[0];
-                    var hasConstructorWithMessageSink = fixtureType.GetConstructor(new[] { typeof(IMessageSink) }) != null;
-                    _assemblyFixtureMappings[fixtureType] = hasConstructorWithMessageSink
-                        ? Activator.CreateInstance(fixtureType, ExecutionMessageSink)
-                        : Activator.CreateInstance(fixtureType);
+                    var hasExecutionMessageSink = fixtureType.GetConstructor(new[] { typeof(IMessageSink) }) != null;
+                    var hasExecutionAndDiagnosticsMessageSink = fixtureType.GetConstructor(new[] { typeof(IMessageSink), typeof(IMessageSink) }) != null;
+
+                    if (hasExecutionAndDiagnosticsMessageSink)
+                    {
+                        _assemblyFixtureMappings[fixtureType] = Activator.CreateInstance(fixtureType, ExecutionMessageSink, DiagnosticMessageSink);
+                    } else if (hasExecutionMessageSink)
+                    {
+                        _assemblyFixtureMappings[fixtureType] = Activator.CreateInstance(fixtureType, ExecutionMessageSink);
+                    } else
+                    {
+                        _assemblyFixtureMappings[fixtureType] = Activator.CreateInstance(fixtureType);
+                    }
                 }
 
                 // Initialize IAsyncLifetime fixtures

--- a/test/Samples.cs
+++ b/test/Samples.cs
@@ -89,6 +89,23 @@ namespace AssemblyFixture.Tests
 		}
 	}
 
+	public class Sample6 : IAssemblyFixture<MyAssemblyFixtureWithDiagnosticsAndExecutionMessageSink>
+	{
+		private readonly MyAssemblyFixtureWithDiagnosticsAndExecutionMessageSink _fixture;
+
+		public Sample6(MyAssemblyFixtureWithDiagnosticsAndExecutionMessageSink fixture)
+		{
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public void EnsureThatHaveIMessageSinks()
+		{
+			Assert.NotNull(_fixture.ExecutionMessageSink);
+            Assert.NotNull(_fixture.DiagnosticsMessageSink);
+        }
+	}
+
 
 	public class MyAssemblyFixture : IDisposable
 	{
@@ -126,6 +143,29 @@ namespace AssemblyFixture.Tests
 			//InstantiationCount = 0;
 		}
 	}
+
+    public class MyAssemblyFixtureWithDiagnosticsAndExecutionMessageSink : IDisposable
+    {
+        public static int InstantiationCount;
+
+        public IMessageSink ExecutionMessageSink { get; }
+
+        public IMessageSink DiagnosticsMessageSink { get; }
+
+        public MyAssemblyFixtureWithDiagnosticsAndExecutionMessageSink(IMessageSink executionMessageSink, IMessageSink diagnosticsMessageSink)
+        {
+            ExecutionMessageSink = executionMessageSink;
+            DiagnosticsMessageSink = diagnosticsMessageSink;
+            InstantiationCount++;
+        }
+
+        public void Dispose()
+        {
+            // Uncomment this and it will surface as an assembly cleanup failure
+            //throw new DivideByZeroException();
+            //InstantiationCount = 0;
+        }
+    }
 
     public class MyAssemblyFixtureWithAsyncLifetime : IAsyncLifetime
     {


### PR DESCRIPTION
This will add the possibility to get both the ExecutionMessageSink and the DiagnosticsMessageSink in a fixture.

This was something we needed, but maybe useful to have for everyone.